### PR TITLE
Python3 támogatás hozzáadása

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.animeaddicts" name="Animeaddicts" version="1.4.5" provider-name="KIZS">
+<addon id="plugin.video.animeaddicts" name="Animeaddicts" version="1.4.6" provider-name="KIZS">
 	<requires>
-		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.requests"/>
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="default.py">

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V.1.4.6
+- Python3 kompatibilitás
+
 V.1.4.5
 - video url javítása
 - certificate check kikapcsolása

--- a/resources/lib/modules/utils.py
+++ b/resources/lib/modules/utils.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
+def py2_encode(s, encoding='utf-8', errors='strict'):
+    """
+    Encode Python 2 ``unicode`` to ``str``
+    In Python 3 the string is not changed.
+    """
+    if sys.version_info[0] == 2 and isinstance(s, unicode):
+        s = s.encode(encoding, errors)
+    return s
+
+def py2_decode(s, encoding='utf-8', errors='strict'):
+    """
+    Decode Python 2 ``str`` to ``unicode``
+    In Python 3 the string is not changed.
+    """
+    if sys.version_info[0] == 2 and isinstance(s, str):
+        s = s.decode(encoding, errors)
+    return s


### PR DESCRIPTION
Megoldási javaslat erre: [#1](https://github.com/vargalex/plugin.video.animeaddicts/issues/1).

Tesztelve:
- Kodi 20.2 (Nexus) @ Vero4K+ (OSMC),
- Kodi 18.9 (Leia) @ LibreELEC-AML.
_Matrix és 18 előtti Kodi-k sajnos nincsenek kéznél, így azokat nem tudtam ellenőrizni._

Azonban nem vagyok Python szakértő, így egy szemrevételezés mindenképp jó lenne.

Addig "faragtam" a kódot, míg hiba nélkül nem ment minden menüpont. Jobbára a te korábbi kódjaid módosításaiból vettem az ötleteket. Azonban a `safeopen` megoldás valamiért itt nem működik, ezért bytestream-ként nyitja meg a fájlokat (animeaddicts.cookies, animeaddicts.db).